### PR TITLE
Allow docker.TGZArchiver to recompress a tarball

### DIFF
--- a/internal/docker/stage.go
+++ b/internal/docker/stage.go
@@ -13,7 +13,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/pkg/stdcopy"
-	"github.com/paketo-buildpacks/packit/v2/vacation"
 )
 
 type StagePhase interface {
@@ -110,7 +109,7 @@ func (s Stage) Run(ctx context.Context, logs io.Writer, containerID, name string
 		}
 
 		if hdr.Name == "droplet" {
-			_, err = io.Copy(dropletFile, tr)
+			_, err = io.CopyN(dropletFile, tr, hdr.Size)
 			if err != nil {
 				return "", fmt.Errorf("failed to copy droplet from tarball: %w", err)
 			}
@@ -140,9 +139,14 @@ func (s Stage) Run(ctx context.Context, logs io.Writer, containerID, name string
 
 		if hdr.Name == "output-cache" {
 			cachePath := filepath.Join(s.workspace, "build-cache", name)
-			err = vacation.NewGzipArchive(tr).Decompress(cachePath)
+			outputFile, err := os.Create(cachePath)
 			if err != nil {
-				return "", fmt.Errorf("failed to decompress build cache: %w", err)
+				return "", fmt.Errorf("failed to create build-cache path: %w", err)
+			}
+
+			_, err = io.CopyN(outputFile, tr, hdr.Size)
+			if err != nil {
+				return "", fmt.Errorf("failed to copy build cache: %w", err)
 			}
 			defer os.RemoveAll(cachePath)
 
@@ -172,7 +176,7 @@ func (s Stage) Run(ctx context.Context, logs io.Writer, containerID, name string
 		}
 
 		if hdr.Name == "result.json" {
-			_, err = io.Copy(buffer, tr)
+			_, err = io.CopyN(buffer, tr, hdr.Size)
 			if err != nil {
 				return "", fmt.Errorf("failed to copy result.json from tarball: %w", err)
 			}

--- a/internal/docker/tgz_archiver.go
+++ b/internal/docker/tgz_archiver.go
@@ -3,6 +3,7 @@ package docker
 import (
 	"archive/tar"
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -42,13 +43,29 @@ func (a TGZArchiver) Compress(input, output string) error {
 	tw := tar.NewWriter(gw)
 	defer tw.Close()
 
-	err = filepath.Walk(input, func(path string, info fs.FileInfo, err error) error {
+	info, err := os.Stat(input)
+	if err != nil {
+		return err
+	}
+
+	switch {
+	case info.IsDir():
+		return a.fromDirectory(input, tw)
+	case info.Mode()&fs.ModeType == 0:
+		return a.fromFile(input, tw)
+	default:
+		return errors.New("unknown file type")
+	}
+}
+
+func (a TGZArchiver) fromDirectory(input string, tw *tar.Writer) error {
+	err := filepath.Walk(input, func(path string, info fs.FileInfo, err error) error {
 		if err != nil {
 			return fmt.Errorf("failed to walk input path: %w", err)
 		}
 
 		var link string
-		if info.Mode()&os.ModeType != 0 && !info.IsDir() {
+		if info.Mode()&fs.ModeSymlink != 0 {
 			link, err = os.Readlink(path)
 			if err != nil {
 				return fmt.Errorf("failed to read symlink: %w", err)
@@ -102,6 +119,49 @@ func (a TGZArchiver) Compress(input, output string) error {
 	})
 	if err != nil {
 		return fmt.Errorf("failed to walk input path: %w", err)
+	}
+
+	return nil
+}
+
+func (a TGZArchiver) fromFile(input string, tw *tar.Writer) error {
+	file, err := os.Open(input)
+	if err != nil {
+		return fmt.Errorf("failed to open file: %w", err)
+	}
+
+	zr, err := gzip.NewReader(file)
+	if err != nil {
+		return fmt.Errorf("failed to read gzip file: %w", err)
+	}
+
+	tr := tar.NewReader(zr)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("failed to read tar header: %w", err)
+		}
+
+		hdr.Name = filepath.Join(a.prefix, hdr.Name)
+		hdr.Uid = 2000
+		hdr.Gid = 2000
+		hdr.Uname = "vcap"
+		hdr.Gname = "vcap"
+
+		err = tw.WriteHeader(hdr)
+		if err != nil {
+			return fmt.Errorf("failed to write tar header: %w", err)
+		}
+
+		if hdr.Typeflag == tar.TypeReg {
+			_, err = io.CopyN(tw, tr, hdr.Size)
+			if err != nil {
+				return fmt.Errorf("failed to copy file: %w", err)
+			}
+		}
 	}
 
 	return nil

--- a/internal/docker/tgz_archiver_test.go
+++ b/internal/docker/tgz_archiver_test.go
@@ -1,9 +1,13 @@
 package docker_test
 
 import (
+	"archive/tar"
+	"compress/gzip"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/cloudfoundry/switchblade/internal/docker"
@@ -48,51 +52,9 @@ func testTGZArchiver(t *testing.T, context spec.G, it spec.S) {
 		Expect(os.RemoveAll(tmpDir)).To(Succeed())
 	})
 
-	it("creates an archive of the given path", func() {
-		err := archiver.Compress(input, output)
-		Expect(err).NotTo(HaveOccurred())
-
-		testOutput := filepath.Join(tmpDir, "test-output")
-		Expect(os.Mkdir(testOutput, os.ModePerm)).To(Succeed())
-
-		file, err := os.Open(output)
-		Expect(err).NotTo(HaveOccurred())
-		defer file.Close()
-
-		err = vacation.NewGzipArchive(file).Decompress(testOutput)
-		Expect(err).NotTo(HaveOccurred())
-
-		files, err := filepath.Glob(filepath.Join(testOutput, "*"))
-		Expect(err).NotTo(HaveOccurred())
-		Expect(files).To(ConsistOf([]string{
-			filepath.Join(testOutput, "some-dir"),
-			filepath.Join(testOutput, "some-file"),
-		}))
-
-		content, err := os.ReadFile(filepath.Join(testOutput, "some-file"))
-		Expect(err).NotTo(HaveOccurred())
-		Expect(string(content)).To(Equal("some-content"))
-
-		info, err := os.Stat(filepath.Join(testOutput, "some-file"))
-		Expect(err).NotTo(HaveOccurred())
-		Expect(info.Mode()).To(Equal(fs.FileMode(0400)))
-
-		content, err = os.ReadFile(filepath.Join(testOutput, "some-dir", "other-file"))
-		Expect(err).NotTo(HaveOccurred())
-		Expect(string(content)).To(Equal("other-content"))
-
-		info, err = os.Stat(filepath.Join(testOutput, "some-dir", "other-file"))
-		Expect(err).NotTo(HaveOccurred())
-		Expect(info.Mode()).To(Equal(fs.FileMode(0600)))
-
-		link, err := os.Readlink(filepath.Join(testOutput, "some-dir", "some-link"))
-		Expect(err).NotTo(HaveOccurred())
-		Expect(link).To(Equal("other-file"))
-	})
-
-	context("when given a prefix", func() {
-		it("includes the prefix on the file paths in the archive", func() {
-			err := archiver.WithPrefix("/some/path").Compress(input, output)
+	context("when the path is a directory", func() {
+		it("creates an archive of the given path", func() {
+			err := archiver.Compress(input, output)
 			Expect(err).NotTo(HaveOccurred())
 
 			testOutput := filepath.Join(tmpDir, "test-output")
@@ -105,45 +67,258 @@ func testTGZArchiver(t *testing.T, context spec.G, it spec.S) {
 			err = vacation.NewGzipArchive(file).Decompress(testOutput)
 			Expect(err).NotTo(HaveOccurred())
 
-			files, err := filepath.Glob(filepath.Join(testOutput, "some", "path", "*"))
+			files, err := filepath.Glob(filepath.Join(testOutput, "*"))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(files).To(ConsistOf([]string{
-				filepath.Join(testOutput, "some", "path", "some-dir"),
-				filepath.Join(testOutput, "some", "path", "some-file"),
+				filepath.Join(testOutput, "some-dir"),
+				filepath.Join(testOutput, "some-file"),
 			}))
 
-			content, err := os.ReadFile(filepath.Join(testOutput, "some", "path", "some-file"))
+			content, err := os.ReadFile(filepath.Join(testOutput, "some-file"))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(content)).To(Equal("some-content"))
 
-			info, err := os.Stat(filepath.Join(testOutput, "some", "path", "some-file"))
+			info, err := os.Stat(filepath.Join(testOutput, "some-file"))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(info.Mode()).To(Equal(fs.FileMode(0400)))
 
-			content, err = os.ReadFile(filepath.Join(testOutput, "some", "path", "some-dir", "other-file"))
+			content, err = os.ReadFile(filepath.Join(testOutput, "some-dir", "other-file"))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(content)).To(Equal("other-content"))
 
-			info, err = os.Stat(filepath.Join(testOutput, "some", "path", "some-dir", "other-file"))
+			info, err = os.Stat(filepath.Join(testOutput, "some-dir", "other-file"))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(info.Mode()).To(Equal(fs.FileMode(0600)))
 
-			link, err := os.Readlink(filepath.Join(testOutput, "some", "path", "some-dir", "some-link"))
+			link, err := os.Readlink(filepath.Join(testOutput, "some-dir", "some-link"))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(link).To(Equal("other-file"))
 		})
+
+		context("when given a prefix", func() {
+			it("includes the prefix on the file paths in the archive", func() {
+				err := archiver.WithPrefix("/some/path").Compress(input, output)
+				Expect(err).NotTo(HaveOccurred())
+
+				testOutput := filepath.Join(tmpDir, "test-output")
+				Expect(os.Mkdir(testOutput, os.ModePerm)).To(Succeed())
+
+				file, err := os.Open(output)
+				Expect(err).NotTo(HaveOccurred())
+				defer file.Close()
+
+				err = vacation.NewGzipArchive(file).Decompress(testOutput)
+				Expect(err).NotTo(HaveOccurred())
+
+				files, err := filepath.Glob(filepath.Join(testOutput, "some", "path", "*"))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(files).To(ConsistOf([]string{
+					filepath.Join(testOutput, "some", "path", "some-dir"),
+					filepath.Join(testOutput, "some", "path", "some-file"),
+				}))
+
+				content, err := os.ReadFile(filepath.Join(testOutput, "some", "path", "some-file"))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(content)).To(Equal("some-content"))
+
+				info, err := os.Stat(filepath.Join(testOutput, "some", "path", "some-file"))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(info.Mode()).To(Equal(fs.FileMode(0400)))
+
+				content, err = os.ReadFile(filepath.Join(testOutput, "some", "path", "some-dir", "other-file"))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(content)).To(Equal("other-content"))
+
+				info, err = os.Stat(filepath.Join(testOutput, "some", "path", "some-dir", "other-file"))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(info.Mode()).To(Equal(fs.FileMode(0600)))
+
+				link, err := os.Readlink(filepath.Join(testOutput, "some", "path", "some-dir", "some-link"))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(link).To(Equal("other-file"))
+			})
+		})
+
+		context("failure cases", func() {
+			context("when a file in the input cannot be opened", func() {
+				it.Before(func() {
+					Expect(os.Chmod(filepath.Join(input, "some-file"), 0000)).To(Succeed())
+				})
+
+				it("returns an error", func() {
+					err := archiver.Compress(input, output)
+					Expect(err).To(MatchError(ContainSubstring("failed to open file:")))
+					Expect(err).To(MatchError(ContainSubstring("permission denied")))
+				})
+			})
+		})
 	})
 
-	context("failure cases", func() {
-		context("when a file in the input cannot be opened", func() {
-			it.Before(func() {
-				Expect(os.Chmod(filepath.Join(input, "some-file"), 0000)).To(Succeed())
-			})
+	context("when the path is a tarball", func() {
+		it.Before(func() {
+			file, err := os.CreateTemp(tmpDir, "input-archive")
+			Expect(err).NotTo(HaveOccurred())
 
-			it("returns an error", func() {
-				err := archiver.Compress(input, output)
-				Expect(err).To(MatchError(ContainSubstring("failed to open file:")))
-				Expect(err).To(MatchError(ContainSubstring("permission denied")))
+			gw := gzip.NewWriter(file)
+			defer gw.Close()
+
+			tw := tar.NewWriter(gw)
+			defer tw.Close()
+
+			err = filepath.Walk(input, func(path string, info fs.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
+
+				var link string
+				if info.Mode()&fs.ModeSymlink != 0 {
+					link, err = os.Readlink(path)
+					if err != nil {
+						return err
+					}
+
+					if !strings.HasPrefix(link, string(filepath.Separator)) {
+						link = filepath.Clean(filepath.Join(filepath.Dir(path), link))
+					}
+
+					link, err = filepath.Rel(filepath.Dir(path), link)
+					if err != nil {
+						return err
+					}
+				}
+
+				hdr, err := tar.FileInfoHeader(info, link)
+				if err != nil {
+					return err
+				}
+
+				hdr.Name, err = filepath.Rel(input, path)
+				if err != nil {
+					return err
+				}
+
+				err = tw.WriteHeader(hdr)
+				if err != nil {
+					return err
+				}
+
+				if info.Mode().IsRegular() {
+					fd, err := os.Open(path)
+					if err != nil {
+						return err
+					}
+					defer fd.Close()
+
+					_, err = io.Copy(tw, fd)
+					if err != nil {
+						return err
+					}
+				}
+
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			input = file.Name()
+		})
+
+		it("creates an archive of the given path", func() {
+			err := archiver.Compress(input, output)
+			Expect(err).NotTo(HaveOccurred())
+
+			testOutput := filepath.Join(tmpDir, "test-output")
+			Expect(os.Mkdir(testOutput, os.ModePerm)).To(Succeed())
+
+			file, err := os.Open(output)
+			Expect(err).NotTo(HaveOccurred())
+			defer file.Close()
+
+			err = vacation.NewGzipArchive(file).Decompress(testOutput)
+			Expect(err).NotTo(HaveOccurred())
+
+			files, err := filepath.Glob(filepath.Join(testOutput, "*"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(files).To(ConsistOf([]string{
+				filepath.Join(testOutput, "some-dir"),
+				filepath.Join(testOutput, "some-file"),
+			}))
+
+			content, err := os.ReadFile(filepath.Join(testOutput, "some-file"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(content)).To(Equal("some-content"))
+
+			info, err := os.Stat(filepath.Join(testOutput, "some-file"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(info.Mode()).To(Equal(fs.FileMode(0400)))
+
+			content, err = os.ReadFile(filepath.Join(testOutput, "some-dir", "other-file"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(content)).To(Equal("other-content"))
+
+			info, err = os.Stat(filepath.Join(testOutput, "some-dir", "other-file"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(info.Mode()).To(Equal(fs.FileMode(0600)))
+
+			link, err := os.Readlink(filepath.Join(testOutput, "some-dir", "some-link"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(link).To(Equal("other-file"))
+		})
+
+		context("when given a prefix", func() {
+			it("includes the prefix on the file paths in the archive", func() {
+				err := archiver.WithPrefix("/some/path").Compress(input, output)
+				Expect(err).NotTo(HaveOccurred())
+
+				testOutput := filepath.Join(tmpDir, "test-output")
+				Expect(os.Mkdir(testOutput, os.ModePerm)).To(Succeed())
+
+				file, err := os.Open(output)
+				Expect(err).NotTo(HaveOccurred())
+				defer file.Close()
+
+				err = vacation.NewGzipArchive(file).Decompress(testOutput)
+				Expect(err).NotTo(HaveOccurred())
+
+				files, err := filepath.Glob(filepath.Join(testOutput, "some", "path", "*"))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(files).To(ConsistOf([]string{
+					filepath.Join(testOutput, "some", "path", "some-dir"),
+					filepath.Join(testOutput, "some", "path", "some-file"),
+				}))
+
+				content, err := os.ReadFile(filepath.Join(testOutput, "some", "path", "some-file"))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(content)).To(Equal("some-content"))
+
+				info, err := os.Stat(filepath.Join(testOutput, "some", "path", "some-file"))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(info.Mode()).To(Equal(fs.FileMode(0400)))
+
+				content, err = os.ReadFile(filepath.Join(testOutput, "some", "path", "some-dir", "other-file"))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(content)).To(Equal("other-content"))
+
+				info, err = os.Stat(filepath.Join(testOutput, "some", "path", "some-dir", "other-file"))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(info.Mode()).To(Equal(fs.FileMode(0600)))
+
+				link, err := os.Readlink(filepath.Join(testOutput, "some", "path", "some-dir", "some-link"))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(link).To(Equal("other-file"))
+			})
+		})
+
+		context("failure cases", func() {
+			context("when the input file cannot be opened", func() {
+				it.Before(func() {
+					Expect(os.Chmod(input, 0000)).To(Succeed())
+				})
+
+				it("returns an error", func() {
+					err := archiver.Compress(input, output)
+					Expect(err).To(MatchError(ContainSubstring("failed to open file:")))
+					Expect(err).To(MatchError(ContainSubstring("permission denied")))
+				})
 			})
 		})
 	})

--- a/matchers/serve_test.go
+++ b/matchers/serve_test.go
@@ -39,7 +39,7 @@ func testServe(t *testing.T, context spec.G, it spec.S) {
 				fmt.Fprint(w, "some string")
 			default:
 				fmt.Fprintln(w, "unknown path")
-				t.Fatal(fmt.Sprintf("unknown path: %s", req.URL.Path))
+				t.Fatalf("unknown path: %s", req.URL.Path)
 			}
 		}))
 

--- a/source_test.go
+++ b/source_test.go
@@ -24,7 +24,7 @@ func testSource(t *testing.T, context spec.G, it spec.S) {
 		source, err = os.MkdirTemp("", "source")
 		Expect(err).NotTo(HaveOccurred())
 
-		err = os.WriteFile(filepath.Join(source, "some-file"), []byte("some-content"), 0644)
+		err = os.WriteFile(filepath.Join(source, "some-file"), []byte("some-content"), 0600)
 		Expect(err).NotTo(HaveOccurred())
 	})
 


### PR DESCRIPTION
This should resolve issues when untarring the build cache using vacation breaks.