### PR TITLE
Use main branch for buildpackapplifecycle repo.

### DIFF
--- a/internal/docker/setup.go
+++ b/internal/docker/setup.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	BuildpackAppLifecycleRepoURL = "https://github.com/cloudfoundry/buildpackapplifecycle/archive/refs/heads/master.zip"
+	BuildpackAppLifecycleRepoURL = "https://github.com/cloudfoundry/buildpackapplifecycle/archive/refs/heads/main.zip"
 	InternalNetworkName          = "switchblade-internal"
 	BridgeNetworkName            = "bridge"
 )

--- a/internal/docker/setup_test.go
+++ b/internal/docker/setup_test.go
@@ -98,7 +98,7 @@ func testSetup(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(containerID).To(Equal("some-container-id"))
 
-			Expect(lifecycleBuilder.BuildCall.Receives.SourceURI).To(Equal("https://github.com/cloudfoundry/buildpackapplifecycle/archive/refs/heads/master.zip"))
+			Expect(lifecycleBuilder.BuildCall.Receives.SourceURI).To(Equal("https://github.com/cloudfoundry/buildpackapplifecycle/archive/refs/heads/main.zip"))
 			Expect(lifecycleBuilder.BuildCall.Receives.Workspace).To(Equal(filepath.Join(workspace, "lifecycle")))
 
 			Expect(archiver.WithPrefixCall.Receives.Prefix).To(Equal("/tmp/app"))


### PR DESCRIPTION
That repo has switched from `master` to `main`.

GitHub redirects from `master` to `main` so this PR isn't particularly time-sensitive.