### PR TITLE
Fix errors with CF when deleting buildpack (multiple stacks)

### DIFF
--- a/internal/cloudfoundry/initialize.go
+++ b/internal/cloudfoundry/initialize.go
@@ -20,11 +20,12 @@ type InitializePhase interface {
 }
 
 type Initialize struct {
-	cli Executable
+	cli   Executable
+	stack string
 }
 
-func NewInitialize(cli Executable) Initialize {
-	return Initialize{cli: cli}
+func NewInitialize(cli Executable, stack string) Initialize {
+	return Initialize{cli: cli, stack: stack}
 }
 
 func (i Initialize) Run(buildpacks []Buildpack) error {
@@ -55,7 +56,7 @@ func (i Initialize) Run(buildpacks []Buildpack) error {
 			}
 
 			err = i.cli.Execute(pexec.Execution{
-				Args:   []string{"delete-buildpack", "-f", buildpack.Name},
+				Args:   []string{"delete-buildpack", "-f", buildpack.Name, "-s", i.stack},
 				Stdout: logs,
 				Stderr: logs,
 			})

--- a/internal/cloudfoundry/initialize_test.go
+++ b/internal/cloudfoundry/initialize_test.go
@@ -43,7 +43,7 @@ func testInitialize(t *testing.T, context spec.G, it spec.S) {
 				return nil
 			}
 
-			initialize = cloudfoundry.NewInitialize(executable)
+			initialize = cloudfoundry.NewInitialize(executable, "test-stack")
 		})
 
 		it("updates the buildpack", func() {
@@ -64,7 +64,7 @@ func testInitialize(t *testing.T, context spec.G, it spec.S) {
 				"Args": Equal([]string{"curl", "/v3/buildpacks?names=some-buildpack-name"}),
 			}))
 			Expect(executions[1]).To(MatchFields(IgnoreExtras, Fields{
-				"Args": Equal([]string{"delete-buildpack", "-f", "some-buildpack-name"}),
+				"Args": Equal([]string{"delete-buildpack", "-f", "some-buildpack-name", "-s", "test-stack"}),
 			}))
 			Expect(executions[2]).To(MatchFields(IgnoreExtras, Fields{
 				"Args": Equal([]string{"create-buildpack", "some-buildpack-name", "some-buildpack-uri", "123"}),
@@ -73,7 +73,7 @@ func testInitialize(t *testing.T, context spec.G, it spec.S) {
 				"Args": Equal([]string{"curl", "/v3/buildpacks?names=other-buildpack-name"}),
 			}))
 			Expect(executions[4]).To(MatchFields(IgnoreExtras, Fields{
-				"Args": Equal([]string{"delete-buildpack", "-f", "other-buildpack-name"}),
+				"Args": Equal([]string{"delete-buildpack", "-f", "other-buildpack-name", "-s", "test-stack"}),
 			}))
 			Expect(executions[5]).To(MatchFields(IgnoreExtras, Fields{
 				"Args": Equal([]string{"create-buildpack", "other-buildpack-name", "other-buildpack-uri", "234"}),
@@ -122,7 +122,7 @@ func testInitialize(t *testing.T, context spec.G, it spec.S) {
 					"Args": Equal([]string{"curl", "/v3/buildpacks?names=other-buildpack-name"}),
 				}))
 				Expect(executions[3]).To(MatchFields(IgnoreExtras, Fields{
-					"Args": Equal([]string{"delete-buildpack", "-f", "other-buildpack-name"}),
+					"Args": Equal([]string{"delete-buildpack", "-f", "other-buildpack-name", "-s", "test-stack"}),
 				}))
 				Expect(executions[4]).To(MatchFields(IgnoreExtras, Fields{
 					"Args": Equal([]string{"create-buildpack", "other-buildpack-name", "other-buildpack-uri", "234"}),

--- a/platform.go
+++ b/platform.go
@@ -59,7 +59,7 @@ func NewPlatform(platformType, token, stack string) (Platform, error) {
 	case CloudFoundry:
 		cli := pexec.NewExecutable("cf")
 
-		initialize := cloudfoundry.NewInitialize(cli)
+		initialize := cloudfoundry.NewInitialize(cli, stack)
 		setup := cloudfoundry.NewSetup(cli, filepath.Join(home, ".cf"), stack)
 		stage := cloudfoundry.NewStage(cli)
 		teardown := cloudfoundry.NewTeardown(cli)


### PR DESCRIPTION
# Context
Given that we configure Toolsmith environments to add support for cflinuxfs4 (for tests) it now adds a set of Buildpacks for the stack, so the resulting environment contains 2 versions of each Buildpack (one for each stack).

When initializing Switchblade in each test suite for use with CF, the Buildpack(s) (referring to the .zip file resulting from the packaging) is passed as an argument.

Internally Switchblade removes any Buildpack containing the same name as the one passed by parameter, but this currently fails because in this scenario we have more than one Buildpack with that name and the platform fails because it requires specifying the stack of the Buildpack to remove.

```bash
$ cf buildpacks
Getting buildpacks...

buildpack               position   enabled   locked   filename                                      stack
staticfile_buildpack    1          true      false    staticfile_buildpack-cflinuxfs3-v1.6.0.zip    cflinuxfs3
java_buildpack          2          true      false    java-buildpack-cflinuxfs3-v4.54.zip           cflinuxfs3
ruby_buildpack          3          true      false    ruby_buildpack-cflinuxfs3-v1.9.3.zip          cflinuxfs3
dotnet_core_buildpack   4          true      false    dotnet-core_buildpack-cflinuxfs3-v2.4.8.zip   cflinuxfs3
nodejs_buildpack        5          true      false    nodejs_buildpack-cflinuxfs3-v1.8.7.zip        cflinuxfs3
go_buildpack            6          true      false    go_buildpack-cflinuxfs3-v1.10.6.zip           cflinuxfs3
python_buildpack        7          true      false    buildpack-cflinuxfs3-v1.2.3-cached.zip        cflinuxfs3
php_buildpack           8          true      false    php_buildpack-cflinuxfs3-v4.6.1.zip           cflinuxfs3
nginx_buildpack         9          true      false    nginx_buildpack-cflinuxfs3-v1.2.1.zip         cflinuxfs3
r_buildpack             10         true      false    r_buildpack-cflinuxfs3-v1.2.0.zip             cflinuxfs3
binary_buildpack        11         true      false    binary_buildpack-cflinuxfs3-v1.1.3.zip        cflinuxfs3
staticfile_buildpack    12         true      false    staticfile_buildpack-cflinuxfs4-v1.6.0.zip    cflinuxfs4
java_buildpack          13         true      false    java-buildpack-cflinuxfs4-v4.54.zip           cflinuxfs4
ruby_buildpack          14         true      false    ruby_buildpack-cflinuxfs4-v1.9.3.zip          cflinuxfs4
dotnet_core_buildpack   15         true      false    dotnet-core_buildpack-cflinuxfs4-v2.4.8.zip   cflinuxfs4
nodejs_buildpack        16         true      false    nodejs_buildpack-cflinuxfs4-v1.8.7.zip        cflinuxfs4
go_buildpack            17         true      false    go_buildpack-cflinuxfs4-v1.10.6.zip           cflinuxfs4
python_buildpack        18         true      false    python_buildpack-cflinuxfs4-v1.8.8.zip        cflinuxfs4
php_buildpack           19         true      false    php_buildpack-cflinuxfs4-v4.6.1.zip           cflinuxfs4
nginx_buildpack         20         true      false    nginx_buildpack-cflinuxfs4-v1.2.1.zip         cflinuxfs4
r_buildpack             21         true      false    r_buildpack-cflinuxfs4-v1.2.0.zip             cflinuxfs4
binary_buildpack        22         true      false    binary_buildpack-cflinuxfs4-v1.1.3.zip        cflinuxfs4
```

```
$ cf delete-buildpack -f python_buildpack
Deleting buildpack python_buildpack...
FAILED
Multiple buildpacks named python_buildpack found. Specify the stack (using -s) to disambiguate.
```

# Solution
Now the stack is a parameter of the `InitializeProcess` and when the deletion is performed it passes the stack as a flag.

Eg:
```
$ cf delete-buildpack -f some_buildpack -s some_stack
```