### PR TITLE
Add WithExpectedStatusCode matcher

### DIFF
--- a/matchers/serve.go
+++ b/matchers/serve.go
@@ -12,19 +12,26 @@ import (
 )
 
 type ServeMatcher struct {
-	expected interface{}
-	endpoint string
-	response string
+	expected           interface{}
+	endpoint           string
+	response           string
+	expectedStatusCode int
 }
 
 func Serve(expected interface{}) *ServeMatcher {
 	return &ServeMatcher{
-		expected: expected,
+		expected:           expected,
+		expectedStatusCode: http.StatusOK,
 	}
 }
 
 func (sm *ServeMatcher) WithEndpoint(endpoint string) *ServeMatcher {
 	sm.endpoint = endpoint
+	return sm
+}
+
+func (sm *ServeMatcher) WithExpectedStatusCode(expectedStatusCode int) *ServeMatcher {
+	sm.expectedStatusCode = expectedStatusCode
 	return sm
 }
 
@@ -54,7 +61,7 @@ func (sm *ServeMatcher) Match(actual interface{}) (success bool, err error) {
 
 	sm.response = string(content)
 
-	if response.StatusCode != http.StatusOK {
+	if response.StatusCode != sm.expectedStatusCode {
 		return false, nil
 	}
 

--- a/matchers/serve_test.go
+++ b/matchers/serve_test.go
@@ -107,6 +107,18 @@ func testServe(t *testing.T, context spec.G, it spec.S) {
 			})
 		})
 
+		context("the response status code matches a custom expected code", func() {
+			it.Before(func() {
+				matcher = matcher.WithEndpoint("/teapot").WithExpectedStatusCode(http.StatusTeapot)
+			})
+
+			it("returns true", func() {
+				result, err := matcher.Match(switchblade.Deployment{ExternalURL: server.URL})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeTrue())
+			})
+		})
+
 		context("failure cases", func() {
 			context("when the matcher is not given a deployment", func() {
 				it("returns an error", func() {


### PR DESCRIPTION
- some buildpacks (like the staticfile) have tests that hit pages with non-200 response codes.
