### PR TITLE
cf: implement manifest.yml

### DIFF
--- a/internal/cloudfoundry/setup.go
+++ b/internal/cloudfoundry/setup.go
@@ -333,6 +333,11 @@ func (s Setup) Run(log io.Writer, home, name, source string) (string, error) {
 		args = append(args, "-c", s.startCommand)
 	}
 
+	_, err = os.Stat(filepath.Join(source, "manifest.yml"))
+	if err == nil {
+		args = append(args, "-f", filepath.Join(source, "manifest.yml"))
+	}
+
 	err = s.cli.Execute(pexec.Execution{
 		Args:   args,
 		Stdout: log,


### PR DESCRIPTION
For certain tests, the app may not field a full http server but simply a trivial tcp server or a looping process. In such cases, CF needs to switch away from the default healthcheck mode of "port". If switchblade supports manifest, this can be provided via a manifest (also all other options supported by the manifest).

See test pre-switchblade-conversion that requires this change: https://github.com/cloudfoundry/ruby-buildpack/blob/v1.10.17/src/ruby/integration/deploy_an_app_with_no_gemfile_test.go#L45

There is no equivalent on the docker platform.