### PR TITLE
Enable docker tests to run on docker-in-docker github runners.

### DIFF
--- a/internal/docker/start_test.go
+++ b/internal/docker/start_test.go
@@ -101,7 +101,7 @@ func testStart(t *testing.T, context spec.G, it spec.S) {
 
 			externalURL, internalURL, err := start.Run(ctx, logs, "some-app", "some-command")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(externalURL).To(Equal("http://0.0.0.0:12345"))
+			Expect(externalURL).To(Equal("http://localhost:12345"))
 			Expect(internalURL).To(Equal("http://172.19.0.2:8080"))
 
 			Expect(client.ContainerCreateCall.Receives.ContainerName).To(Equal("some-app"))


### PR DESCRIPTION
- This is taken from https://github.com/paketo-buildpacks/occam/blob/f760b3a28c334d3d14ebd38f447c21a90228f3b3/container.go#L74-L86
  where it has been tested for years on various platforms.
- This has been validated locally on OSX and linux machines, as well as in docker-in-docker GitHub runners.
